### PR TITLE
Handle missing Kùzu dependency gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,22 @@ graphiti = Graphiti(
 # Now you can use Graphiti with Google Gemini
 ```
 
+## Using Graphiti with Kùzu
+
+Graphiti can also run on the [Kùzu](https://kuzudb.com) graph database. Use a
+`kuzu://` URI that points to your database directory when creating the
+`Graphiti` instance.
+
+```python
+from graphiti_core import Graphiti
+
+graphiti = Graphiti(
+    "kuzu:///path/to/db",
+    "",  # username not required
+    "",  # password not required
+)
+```
+
 ## Documentation
 
 - [Guides and API documentation](https://help.getzep.com/graphiti).

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -104,40 +104,9 @@ class Graphiti:
         store_raw_episode_content: bool = True,
     ):
         """
-        Initialize a Graphiti instance.
-
-        This constructor sets up a connection to the Neo4j database and initializes
-        the LLM client for natural language processing tasks.
-
-        Parameters
-        ----------
-        uri : str
-            The URI of the Neo4j database.
-        user : str
-            The username for authenticating with the Neo4j database.
-        password : str
-            The password for authenticating with the Neo4j database.
-        llm_client : LLMClient | None, optional
-            An instance of LLMClient for natural language processing tasks.
-            If not provided, a default OpenAIClient will be initialized.
-
-        Returns
-        -------
-        None
-
-        Notes
-        -----
-        This method establishes a connection to the Neo4j database using the provided
-        credentials. It also sets up the LLM client, either using the provided client
-        or by creating a default OpenAIClient.
-
-        The default database name is set to 'neo4j'. If a different database name
-        is required, it should be specified in the URI or set separately after
-        initialization.
-
-        The OpenAI API key is expected to be set in the environment variables.
-        Make sure to set the OPENAI_API_KEY environment variable before initializing
-        Graphiti if you're using the default OpenAIClient.
+        Initializes a Graphiti instance with database and NLP service connections.
+        
+        Establishes a connection to either a Neo4j or Kuzu database based on the URI scheme, and sets up clients for language modeling, embedding, and cross-encoder services. If custom clients are not provided, defaults are used. Optionally configures whether to store raw episode content.
         """
         self.driver: Any
         if uri.startswith('kuzu://'):

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -17,6 +17,7 @@ limitations under the License.
 import logging
 from datetime import datetime
 from time import time
+from typing import Any
 
 from dotenv import load_dotenv
 from neo4j import AsyncGraphDatabase
@@ -45,6 +46,7 @@ from graphiti_core.search.search_utils import (
     get_mentioned_nodes,
     get_relevant_edges,
 )
+from graphiti_core.storage import KuzuDriverAdapter
 from graphiti_core.utils.bulk_utils import (
     RawEpisode,
     add_nodes_and_edges_bulk,
@@ -137,7 +139,12 @@ class Graphiti:
         Make sure to set the OPENAI_API_KEY environment variable before initializing
         Graphiti if you're using the default OpenAIClient.
         """
-        self.driver = AsyncGraphDatabase.driver(uri, auth=(user, password))
+        self.driver: Any
+        if uri.startswith('kuzu://'):
+            db_path = uri[len('kuzu://') :]
+            self.driver = KuzuDriverAdapter(db_path)
+        else:
+            self.driver = AsyncGraphDatabase.driver(uri, auth=(user, password))
         self.database = DEFAULT_DATABASE
         self.store_raw_episode_content = store_raw_episode_content
         if llm_client:

--- a/graphiti_core/graphiti_types.py
+++ b/graphiti_core/graphiti_types.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from typing import Any
+
 from neo4j import AsyncDriver
 from pydantic import BaseModel, ConfigDict
 
@@ -23,7 +25,7 @@ from graphiti_core.llm_client import LLMClient
 
 
 class GraphitiClients(BaseModel):
-    driver: AsyncDriver
+    driver: Any | AsyncDriver
     llm_client: LLMClient
     embedder: EmbedderClient
     cross_encoder: CrossEncoderClient

--- a/graphiti_core/storage/__init__.py
+++ b/graphiti_core/storage/__init__.py
@@ -1,0 +1,1 @@
+from .kuzu_driver import KuzuDriverAdapter

--- a/graphiti_core/storage/kuzu_driver.py
+++ b/graphiti_core/storage/kuzu_driver.py
@@ -10,6 +10,15 @@ class KuzuDriverAdapter:
     """Simple adapter to mimic neo4j.AsyncDriver.execute_query using Kùzu."""
 
     def __init__(self, db_path: str):
+        """
+        Initializes a KuzuDriverAdapter with an asynchronous connection to a Kùzu database.
+        
+        Args:
+            db_path: Path to the Kùzu database file.
+        
+        Raises:
+            ImportError: If the Kùzu library is not installed.
+        """
         if kuzu is None:  # pragma: no cover - optional dependency
             msg = 'Kùzu is not installed. Install with "pip install kuzu"'
             raise ImportError(msg)
@@ -17,11 +26,26 @@ class KuzuDriverAdapter:
         self.conn = kuzu.AsyncConnection(self.database)
 
     async def close(self) -> None:
+        """
+        Closes the asynchronous connection to the Kùzu database.
+        """
         await self.conn.close()
 
     async def execute_query(self, query: str, **parameters: Any):
         # neo4j's execute_query accepts database_ and routing_ kwargs which
         # are ignored here
+        """
+        Executes a Cypher-like query asynchronously and returns the results.
+        
+        Removes unsupported `database_` and `routing_` parameters for compatibility with the neo4j interface. Returns a tuple containing a list of result rows as dictionaries, `None` as a placeholder for summary, and the list of column names.
+        
+        Args:
+            query: The Cypher-like query string to execute.
+            **parameters: Query parameters.
+        
+        Returns:
+            A tuple of (rows, None, column_names), where rows is a list of dictionaries mapping column names to values, and column_names is a list of column names.
+        """
         parameters.pop('database_', None)
         parameters.pop('routing_', None)
         result = await self.conn.execute(query, parameters or None)

--- a/graphiti_core/storage/kuzu_driver.py
+++ b/graphiti_core/storage/kuzu_driver.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import kuzu  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    kuzu = None
+
+
+class KuzuDriverAdapter:
+    """Simple adapter to mimic neo4j.AsyncDriver.execute_query using Kùzu."""
+
+    def __init__(self, db_path: str):
+        if kuzu is None:  # pragma: no cover - optional dependency
+            msg = 'Kùzu is not installed. Install with "pip install kuzu"'
+            raise ImportError(msg)
+        self.database = kuzu.Database(db_path)
+        self.conn = kuzu.AsyncConnection(self.database)
+
+    async def close(self) -> None:
+        await self.conn.close()
+
+    async def execute_query(self, query: str, **parameters: Any):
+        # neo4j's execute_query accepts database_ and routing_ kwargs which
+        # are ignored here
+        parameters.pop('database_', None)
+        parameters.pop('routing_', None)
+        result = await self.conn.execute(query, parameters or None)
+        cols = result.get_column_names()
+        rows = []
+        while result.has_next():
+            row = result.get_next()
+            rows.append({c: v for c, v in zip(cols, row, strict=False)})
+        return rows, None, cols


### PR DESCRIPTION
## Summary
- keep Kùzu support optional by deferring import
- raise a helpful ImportError if the library isn't installed

## Testing
- `poetry run ruff check graphiti_core/graphiti.py graphiti_core/storage/kuzu_driver.py graphiti_core/graphiti_types.py`
- `poetry run ruff format graphiti_core/graphiti.py graphiti_core/storage/kuzu_driver.py graphiti_core/graphiti_types.py`
- `poetry run mypy graphiti_core/storage/kuzu_driver.py graphiti_core/graphiti.py graphiti_core/graphiti_types.py`
- `poetry run pytest -k "none"`

------
https://chatgpt.com/codex/tasks/task_e_6848f4630aa8832ca68d29c2a02dae69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to Kùzu graph databases using a `kuzu://` URI.
- **Documentation**
  - Updated the README with instructions and a code example for using Graphiti with Kùzu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->